### PR TITLE
Mostrar el equipamiento antes de los horarios

### DIFF
--- a/src/asignacion_aulica/GUI/QML/Edificios/Aulas.qml
+++ b/src/asignacion_aulica/GUI/QML/Edificios/Aulas.qml
@@ -77,14 +77,14 @@ ListView {
 
         Item { } // Espacio vacío de 2 * spacing de ancho
 
-        EditorHorariosSemanales { }
-
-        Item { } // Espacio vacío de 2 * spacing de ancho
-
         SelectorEquipamiento {
             Layout.preferredWidth: headerItem.widthEquipamiento
             aula: parent.aula
         }
+
+        Item { } // Espacio vacío de 2 * spacing de ancho
+
+        EditorHorariosSemanales { }
 
         BotónBorrar {
             onClicked: {

--- a/src/asignacion_aulica/GUI/QML/Edificios/HeaderAulas.qml
+++ b/src/asignacion_aulica/GUI/QML/Edificios/HeaderAulas.qml
@@ -56,15 +56,15 @@ RowLayout {
 
     Item { } // Espacio vacío de 2 * spacing de ancho
 
-    HeaderHorariosSemanales { }
-
-    Item { } // Espacio vacío de 2 * spacing de ancho
-
     Label {
         id: headerEquipamiento
-        leftPadding: 50
-        rightPadding: 50
+        leftPadding: 40
+        rightPadding: 40
         Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
         text: "Equipamiento"
     }
+
+    Item { } // Espacio vacío de 2 * spacing de ancho
+
+    HeaderHorariosSemanales { }
 }


### PR DESCRIPTION
Me pareció que era mejor en este orden porque los horarios de las aulas casi nunca van a ser distintos de los del edificio, así que tiene sentido darle menos importancia visualmente